### PR TITLE
update the repo address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Legion is a GPU-initiated system for large-scale GNN training.
 ```
-$ git clone https://github.com/JIESUN233/Legion.git
+$ git clone https://github.com/RC4ML/Legion.git
 ```
 
 ## 1. Hardware 


### PR DESCRIPTION
It seems we still use the address from the previous repo, which has a different file structure and can not go along with the following instructions.