### PR TITLE
fix build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,6 @@ cd sampling_server && \
 make clean && make -j 8 && \
 cd .. && \
 cd training_backend && \
+export CUDA_HOME=/usr/local/cuda && \
 python setup.py install && \ 
 cd ..


### PR DESCRIPTION
Using `os.environ['CUDA_HOME'] = '/usr/local/cuda'` inside setup.py makes the environment variable effective only within the Python process and won't affect the variable in the external shell environment. Use `export CUDA_HOME=/usr/local/cuda `in the build.sh script instead.